### PR TITLE
change TextTokenizer 2DConvolution to 1D

### DIFF
--- a/src/text/cct.py
+++ b/src/text/cct.py
@@ -1,6 +1,6 @@
 import torch.nn as nn
 from ..utils.transformers import MaskedTransformerClassifier
-from ..utils.tokenizer import TextTokenizer
+from ..utils.tokenizer import TextTokenizer1D
 from ..utils.embedder import Embedder
 
 __all__ = [
@@ -27,7 +27,7 @@ class TextCCT(nn.Module):
         self.embedder = Embedder(word_embedding_dim=word_embedding_dim,
                                  *args, **kwargs)
 
-        self.tokenizer = TextTokenizer(n_input_channels=word_embedding_dim,
+        self.tokenizer = TextTokenizer1D(n_input_channels=word_embedding_dim,
                                        n_output_channels=embedding_dim,
                                        kernel_size=kernel_size,
                                        stride=stride,


### PR DESCRIPTION
Hello,

It seems to make more intuitive sense to use 1D convolutions here over the embedding with a channel size equal to the word embedding dimension, rather than the edge-case of a 2D convolution as is currently implemented. I would personally make this change to match other networks with similar convolutions over nn.Embeddings. I believe this has no change to performance but rather is presented for clarity. Thank you