### PR TITLE
Fix checkpoint loading issues

### DIFF
--- a/src/cct.py
+++ b/src/cct.py
@@ -89,6 +89,7 @@ class CCT(nn.Module):
 def _cct(arch, pretrained, progress,
          num_layers, num_heads, mlp_ratio, embedding_dim,
          kernel_size=3, stride=None, padding=None,
+         positional_embedding='learnable',
          *args, **kwargs):
     stride = stride if stride is not None else max(1, (kernel_size // 2) - 1)
     padding = padding if padding is not None else max(1, (kernel_size // 2))
@@ -105,7 +106,8 @@ def _cct(arch, pretrained, progress,
         if arch in model_urls:
             state_dict = load_state_dict_from_url(model_urls[arch],
                                                   progress=progress)
-            state_dict = pe_check(model, state_dict)
+            if positional_embedding == 'learnable':
+                state_dict = pe_check(model, state_dict)
             state_dict = fc_check(model, state_dict)
             model.load_state_dict(state_dict)
         else:

--- a/src/cvt.py
+++ b/src/cvt.py
@@ -64,7 +64,8 @@ class CVT(nn.Module):
 
 def _cvt(arch, pretrained, progress,
          num_layers, num_heads, mlp_ratio, embedding_dim,
-         kernel_size=4, *args, **kwargs):
+         kernel_size=4, positional_embedding='learnable',
+         *args, **kwargs):
     model = CVT(num_layers=num_layers,
                 num_heads=num_heads,
                 mlp_ratio=mlp_ratio,
@@ -75,7 +76,8 @@ def _cvt(arch, pretrained, progress,
     if pretrained and arch in model_urls:
         state_dict = load_state_dict_from_url(model_urls[arch],
                                               progress=progress)
-        state_dict = pe_check(model, state_dict)
+        if positional_embedding == 'learnable':
+            state_dict = pe_check(model, state_dict)
         model.load_state_dict(state_dict)
     return model
 

--- a/src/utils/transformers.py
+++ b/src/utils/transformers.py
@@ -252,6 +252,7 @@ class MaskedTransformerClassifier(Module):
         self.embedding_dim = embedding_dim
         self.seq_len = seq_len
         self.seq_pool = seq_pool
+        self.num_tokens = 0
 
         assert seq_len is not None or positional_embedding == 'none', \
             f"Positional embedding is set to {positional_embedding} and" \
@@ -261,6 +262,7 @@ class MaskedTransformerClassifier(Module):
             seq_len += 1
             self.class_emb = Parameter(torch.zeros(1, 1, self.embedding_dim),
                                        requires_grad=True)
+            self.num_tokens = 1
         else:
             self.attention_pool = Linear(self.embedding_dim, 1)
 

--- a/src/utils/transformers.py
+++ b/src/utils/transformers.py
@@ -150,6 +150,7 @@ class TransformerClassifier(Module):
         self.embedding_dim = embedding_dim
         self.sequence_length = sequence_length
         self.seq_pool = seq_pool
+        self.num_tokens = 0
 
         assert sequence_length is not None or positional_embedding == 'none', \
             f"Positional embedding is set to {positional_embedding} and" \
@@ -159,6 +160,7 @@ class TransformerClassifier(Module):
             sequence_length += 1
             self.class_emb = Parameter(torch.zeros(1, 1, self.embedding_dim),
                                        requires_grad=True)
+            self.num_tokens = 1
         else:
             self.attention_pool = Linear(self.embedding_dim, 1)
 

--- a/src/vit.py
+++ b/src/vit.py
@@ -70,11 +70,14 @@ def _vit_lite(arch, pretrained, progress,
                     mlp_ratio=mlp_ratio,
                     embedding_dim=embedding_dim,
                     kernel_size=kernel_size,
+                    positional_embedding='learnable',
                     *args, **kwargs)
 
     if pretrained and arch in model_urls:
         state_dict = load_state_dict_from_url(model_urls[arch],
                                               progress=progress)
+        if positional_embedding == 'learnable':
+            state_dict = pe_check(model, state_dict)
         state_dict = pe_check(model, state_dict)
         model.load_state_dict(state_dict)
     return model


### PR DESCRIPTION
The last branch that we merged had a `pe_check` method, which checks the positional embedding weights in the state dictionary to see if the size matches the model image size. This is useful when a pretrained checkpoint with learnable PE is loaded and the resolutions don't match.

However, there were two mistakes: 1. it wasn't merged 2. the method should not be called when PE is sinusoidal.
Those two errors should be fixed by this PR.