### PR TITLE
Fixed text tokenizer mask shape

### DIFF
--- a/src/utils/tokenizer.py
+++ b/src/utils/tokenizer.py
@@ -101,8 +101,8 @@ class TextTokenizer(nn.Module):
         x = self.conv_layers(x)
         x = x.transpose(1, 3).squeeze(1)
         if mask is not None:
-            mask = self.forward_mask(mask).unsqueeze(-1).float()
-            x = x * mask
+            mask = self.forward_mask(mask)
+            x = x * mask.unsqueeze(-1).float()
         return x, mask
 
     @staticmethod


### PR DESCRIPTION
Hi,

There was a small problem with the mask returned from TextTokenizer forward function.
The next function using this mask needs a 2D tensor. Therefore, in TextTokenizer, the mask should not be unsqueezed before being returned.

The problem is fixed in this pull request.