### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.sw?
 __pycache__
 examples/src
+*.pth

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.sw?
+__pycache__
+examples/src

--- a/examples/utils/autoaug.py
+++ b/examples/utils/autoaug.py
@@ -122,7 +122,7 @@ class SubPolicy(object):
             "translateY": np.linspace(0, 150 / 331, 10),
             "rotate": np.linspace(0, 30, 10),
             "color": np.linspace(0.0, 0.9, 10),
-            "posterize": np.round(np.linspace(8, 4, 10), 0).astype(np.int),
+            "posterize": np.round(np.linspace(8, 4, 10), 0).astype(np.int32),
             "solarize": np.linspace(256, 0, 10),
             "contrast": np.linspace(0.0, 0.9, 10),
             "sharpness": np.linspace(0.0, 0.9, 10),

--- a/src/cct.py
+++ b/src/cct.py
@@ -117,26 +117,31 @@ def _cct(arch, pretrained, progress,
     return model
 
 
+@register_model
 def cct_2(arch, pretrained, progress, *args, **kwargs):
     return _cct(arch, pretrained, progress, num_layers=2, num_heads=2, mlp_ratio=1, embedding_dim=128,
                 *args, **kwargs)
 
 
+@register_model
 def cct_4(arch, pretrained, progress, *args, **kwargs):
     return _cct(arch, pretrained, progress, num_layers=4, num_heads=2, mlp_ratio=1, embedding_dim=128,
                 *args, **kwargs)
 
 
+@register_model
 def cct_6(arch, pretrained, progress, *args, **kwargs):
     return _cct(arch, pretrained, progress, num_layers=6, num_heads=4, mlp_ratio=2, embedding_dim=256,
                 *args, **kwargs)
 
 
+@register_model
 def cct_7(arch, pretrained, progress, *args, **kwargs):
     return _cct(arch, pretrained, progress, num_layers=7, num_heads=4, mlp_ratio=2, embedding_dim=256,
                 *args, **kwargs)
 
 
+@register_model
 def cct_14(arch, pretrained, progress, *args, **kwargs):
     return _cct(arch, pretrained, progress, num_layers=14, num_heads=6, mlp_ratio=3, embedding_dim=384,
                 *args, **kwargs)


### PR DESCRIPTION
- numpy deprecation (`np.int` -> `np.int32`)
- register abstract models (e.g. `cct_2`)
- add `.gitignore`

tested colab notebook on my repo and it ran

timm still deprecated and this will die in the future